### PR TITLE
Added updated_at filter for /calendar_event. Added created_at and upd…

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -713,6 +713,11 @@ paths:
           type: string
           description: |
             The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events created in November 2017 (America/New_York): `filter[created_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
+        - name: filter[updated_at]
+          in: query
+          type: string
+          description: |
+            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events updated in November 2017 (America/New_York): `filter[updated_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
         - name: page[number]
           in: query
           description: Page number
@@ -1347,6 +1352,16 @@ paths:
           in: query
           type: boolean
           description: If not specified, return all patients. If set to 'true' return only archived patients, if set to 'false', return only patients who are not archived.
+        - name: filter[created_at]
+          in: query
+          type: string
+          description: |
+            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events created in November 2017 (America/New_York): `filter[created_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
+        - name: filter[updated_at]
+          in: query
+          type: string
+          description: |
+            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events updated in November 2017 (America/New_York): `filter[updated_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
         - name: page[number]
           in: query
           description: Page number

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1356,12 +1356,12 @@ paths:
           in: query
           type: string
           description: |
-            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events created in November 2017 (America/New_York): `filter[created_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
+            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for patients created in November 2017 (America/New_York): `filter[created_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
         - name: filter[updated_at]
           in: query
           type: string
           description: |
-            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events updated in November 2017 (America/New_York): `filter[updated_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
+            The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for patients updated in November 2017 (America/New_York): `filter[updated_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
         - name: page[number]
           in: query
           description: Page number


### PR DESCRIPTION
Added `created_at` and `updated_at` filters to `/patient` public collection api. Added `updated_at` filter to `/calendar_event` public collection api.  See related TwinServer PR [here](https://github.com/TwineHealth/TwineServer/pull/564).