### PR TITLE
Calendar api crud 4818

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -665,7 +665,7 @@ paths:
           schema:
             $ref: '#/definitions/CreateCalendarEventRequest'
       responses:
-        '200':
+        '201':
           description: OK
           schema:
             $ref: '#/definitions/CreateCalendarEventResponse'
@@ -2021,9 +2021,6 @@ definitions:
   # BEGIN resource definitions
   Resource:
     type: object
-    required:
-      - type
-      - id
     properties:
       type:
         type: string
@@ -3285,8 +3282,6 @@ definitions:
   # BEGIN /calendar_event definitions
   CalendarEventResource:
     type: object
-    required:
-      - type
     properties:
       type:
         type: string
@@ -3353,21 +3348,19 @@ definitions:
                     - tentative
                     - accepted
       links:
-         type: object
-         readOnly: true
-         required:
-           - self
-         properties:
-           self:
-             type: string
-             pattern: '/calendar_event/[0-9a-z]+'
-             example: '/calendar_event/5a0c8e2aa9d454cc1509a142'
+       type: object
+       properties:
+         self:
+           type: string
+           pattern: '/calendar_event/[0-9a-z]+'
+           example: '/calendar_event/5a0c8e2aa9d454cc1509a142'
       relationships:
         type: object
         properties:
           owner:
             type: object
-            readOnly: true
+            required:
+              - owner
             properties:
               data:
                 type: object
@@ -3378,7 +3371,6 @@ definitions:
                     type: string
               links:
                 type: object
-                readOnly: true
                 properties:
                   related:
                     type: string
@@ -3402,6 +3394,9 @@ definitions:
                {
                    "user": "5a0c8e27a9d454cc150997c9",
                    "response_status": "accepted"
+               }, {
+                "user": "5a0c8e27a9d454cc150997f7",
+                "response_status": "needsAction"
                }
            ],
            "created_at": "2017-10-20T10:59:40.000Z",
@@ -3430,11 +3425,68 @@ definitions:
       - data
     properties:
       data:
-        $ref: '#/definitions/CalendarEventResource'
+        required:
+          - type
+          - attributes
+          - relationships
+        properties:
+          type:
+            $ref: "#/definitions/CalendarEventResource/properties/type"
+          attributes:
+            required:
+              - type
+              - start_at
+              - title
+              - attendees
+            allOf:
+              - $ref: "#/definitions/CalendarEventResource/properties/attributes"
+          relationships:
+            type: object
+            properties:
+              owner:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/definitions/CalendarEventResource/properties/relationships/properties/owner/properties/data"
+    example:
+      {
+        "data": {
+          "type": "calendar event",
+          "attributes": {
+            "completed_at": "2017-11-03T06:17:34.652Z",
+            "completed_by": "5a0c8e27a9d454cc150997c9",
+            "type": "plan-check-in",
+            "time_zone": "America/New_York",
+            "all_day": true,
+            "start_at": "2017-11-03T04:00:00.000Z",
+            "end_at": "2017-11-03T08:00:00.000Z",
+            "title": "Plan Check-In",
+            "attendees": [
+              {
+                "user": "5a0c8e27a9d454cc150997c9",
+                "response_status": "accepted"
+              }, {
+                "user": "5a0c8e27a9d454cc150997f7",
+                "response_status": "needsAction"
+              }
+            ],
+          },
+          "relationships": {
+            "owner": {
+              "data": [
+                {
+                  "type": "patient",
+                  "id": "5a0c8e27a9d454cc150997f7"
+                }
+              ]
+            }
+          }
+        }
+      }
   CreateCalendarEventResponse:
     type: object
-    required:
-      - data
     properties:
       meta:
         $ref: '#/definitions/CreateOrUpdateMetaResponse'
@@ -3442,15 +3494,59 @@ definitions:
         $ref: '#/definitions/CalendarEventResource'
   UpdateCalendarEventRequest:
     type: object
-    required:
-      - data
     properties:
       data:
-        $ref: '#/definitions/CalendarEventResource'
+        properties:
+          type:
+            $ref: "#/definitions/CalendarEventResource/properties/type"
+          attributes:
+            allOf:
+              - $ref: "#/definitions/CalendarEventResource/properties/attributes"
+          relationships:
+            type: object
+            properties:
+              owner:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/definitions/CalendarEventResource/properties/relationships/properties/owner/properties/data"
+    example:
+      {
+        "data": {
+          "type": "calendar event",
+          "attributes": {
+            "completed_at": "2017-11-03T06:17:34.652Z",
+            "completed_by": "5a0c8e27a9d454cc150997c9",
+            "type": "plan-check-in",
+            "time_zone": "America/New_York",
+            "all_day": true,
+            "start_at": "2017-11-03T04:00:00.000Z",
+            "end_at": "2017-11-03T08:00:00.000Z",
+            "title": "Plan Check-In",
+            "attendees": [
+              {
+                "user": "5a0c8e27a9d454cc150997c9",
+                "response_status": "accepted"
+              }, {
+                "user": "5a0c8e27a9d454cc150997f7",
+                "response_status": "needsAction"
+              }
+            ],
+          },
+          "relationships": {
+            "owner": {
+              "data": [
+                {
+                  "type": "patient",
+                  "id": "5a0c8e27a9d454cc150997f7"
+                }
+              ]
+            }
+          }
+        }
+      }
   UpdateCalendarEventResponse:
     type: object
-    required:
-      - data
     properties:
       meta:
         $ref: '#/definitions/CreateOrUpdateMetaResponse'
@@ -3458,8 +3554,6 @@ definitions:
         $ref: '#/definitions/CalendarEventResource'
   FetchCalendarEventResponse:
     type: object
-    required:
-      - data
     properties:
       meta:
         $ref: '#/definitions/FetchMetaResponse'
@@ -3475,8 +3569,6 @@ definitions:
           $ref: '#/definitions/Resource'
   FetchCalendarEventsResponse:
     type: object
-    required:
-      - data
     properties:
       meta:
         $ref: '#/definitions/FetchMetaResponse'

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -656,7 +656,7 @@ paths:
       tags:
         - calendar event
       summary: Create calendar event
-      description: Create a calendar event for a patient.
+      description: Create a calendar event for a patient. Attribute `all_day` cannot be specified for `plan-check-in` event type.
       operationId: createCalendarEvent
       parameters:
         - name: body
@@ -814,7 +814,7 @@ paths:
       tags:
         - calendar event
       summary: Update a calendar event
-      description: Update a calendar event for a patient.
+      description: Update a calendar event for a patient. Attribute `all_day` cannot be specified for `plan-check-in` event type.
       operationId: updateCalendarEvent
       parameters:
         - name: id
@@ -3308,6 +3308,8 @@ definitions:
     properties:
       type:
         type: string
+        enum:
+          - calendar_event
       id:
         type: string
       attributes:
@@ -3476,7 +3478,7 @@ definitions:
     example:
       {
         "data": {
-          "type": "calendar event",
+          "type": "calendar_event",
           "attributes": {
             "completed_at": "2017-11-03T06:17:34.652Z",
             "completed_by": "5a0c8e27a9d454cc150997c9",
@@ -3519,9 +3521,14 @@ definitions:
     type: object
     properties:
       data:
+        required:
+          - type
+          - id
         properties:
           type:
             $ref: "#/definitions/CalendarEventResource/properties/type"
+          id:
+            $ref: "#/definitions/CalendarEventResource/properties/id"
           attributes:
             allOf:
               - $ref: "#/definitions/CalendarEventResource/properties/attributes"
@@ -3536,7 +3543,8 @@ definitions:
     example:
       {
         "data": {
-          "type": "calendar event",
+          "type": "calendar_event",
+          "id": "42ba7c2da9d45415234345b3",
           "attributes": {
             "completed_at": "2017-11-03T06:17:34.652Z",
             "completed_by": "5a0c8e27a9d454cc150997c9",

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -529,7 +529,7 @@ paths:
       tags:
         - action
       summary: Update an action
-      description: Updte a health action from a patient's plan.
+      description: Update a health action from a patient's plan.
       operationId: updateAction
       parameters:
         - name: id
@@ -652,6 +652,35 @@ paths:
             $ref: '#/definitions/CreateOrUpdateErrorResponse'
 
   /calendar_event:
+    post:
+      tags:
+        - calendar event
+      summary: Create calendar event
+      description: Create a calendar event for a patient.
+      operationId: createCalendarEvent
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CreateCalendarEventRequest'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CreateCalendarEventResponse'
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/CreateOrUpdateErrorResponse'
+        '403':
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/CreateOrUpdateErrorResponse'
+        '409':
+          description: Invalid Request
+          schema:
+            $ref: '#/definitions/CreateOrUpdateErrorResponse'
     get:
       tags:
         - calendar event
@@ -781,6 +810,40 @@ paths:
           description: Forbidden
           schema:
             $ref: '#/definitions/FetchErrorResponse'
+    patch:
+      tags:
+        - calendar event
+      summary: Update a calendar event
+      description: Update a calendar event for a patient.
+      operationId: updateCalendarEvent
+      parameters:
+        - name: id
+          in: path
+          description: Calendar event identifier
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateCalendarEventRequest'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/UpdateCalendarEventResponse'
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/FetchErrorResponse'
+        '403':
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/FetchErrorResponse'
+        '409':
+          description: Invalid Request
+          schema:
+            $ref: '#/definitions/CreateOrUpdateErrorResponse'
 
   /email_history:
     get:
@@ -2617,6 +2680,22 @@ definitions:
                     type: string
                   id:
                     type: string
+  CreateRewardProgramRequest:
+    type: object
+    required:
+      - data
+    properties:
+      data:
+        $ref: '#/definitions/RewardProgramResource'
+  CreateRewardProgramResponse:
+    type: object
+    required:
+      - data
+    properties:
+      meta:
+        $ref: '#/definitions/CreateOrUpdateMetaResponse'
+      data:
+        $ref: '#/definitions/RewardProgramResource'
   FetchRewardProgramResponse:
     type: object
     required:
@@ -2637,22 +2716,6 @@ definitions:
           type: array
           items:
             $ref: '#/definitions/RewardProgramResource'
-  CreateRewardProgramRequest:
-    type: object
-    required:
-      - data
-    properties:
-      data:
-        $ref: '#/definitions/RewardProgramResource'
-  CreateRewardProgramResponse:
-    type: object
-    required:
-      - data
-    properties:
-      meta:
-        $ref: '#/definitions/CreateOrUpdateMetaResponse'
-      data:
-        $ref: '#/definitions/RewardProgramResource'
   # END /reward_program definitions
 
   # BEGIN /action definitions
@@ -3361,6 +3424,38 @@ definitions:
            "self": "/pub/calendar_event/5a0c8e2aa9d454cc1509a142"
          },
      }
+  CreateCalendarEventRequest:
+    type: object
+    required:
+      - data
+    properties:
+      data:
+        $ref: '#/definitions/CalendarEventResource'
+  CreateCalendarEventResponse:
+    type: object
+    required:
+      - data
+    properties:
+      meta:
+        $ref: '#/definitions/CreateOrUpdateMetaResponse'
+      data:
+        $ref: '#/definitions/CalendarEventResource'
+  UpdateCalendarEventRequest:
+    type: object
+    required:
+      - data
+    properties:
+      data:
+        $ref: '#/definitions/CalendarEventResource'
+  UpdateCalendarEventResponse:
+    type: object
+    required:
+      - data
+    properties:
+      meta:
+        $ref: '#/definitions/CreateOrUpdateMetaResponse'
+      data:
+        $ref: '#/definitions/CalendarEventResource'
   FetchCalendarEventResponse:
     type: object
     required:

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -844,6 +844,29 @@ paths:
           description: Invalid Request
           schema:
             $ref: '#/definitions/CreateOrUpdateErrorResponse'
+    delete:
+      tags:
+        - calendar event
+      summary: Delete a calendar event
+      description: Delete a calendar event by id
+      operationId: deleteCalendarEvent
+      parameters:
+        - name: id
+          in: path
+          description: Calendar event identifier
+          required: true
+          type: string
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/FetchErrorResponse'
+        '403':
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/FetchErrorResponse'
 
   /email_history:
     get:


### PR DESCRIPTION
Added `POST`, `PATCH` and `DELETE` verbs for calendar event endpoints in public api documentation.  Ensured that `ids` and `links` are not specified in these new verbs' documentation.  Marked `required` fields in request body but not in response body.