### PR TITLE
Use public calendar api 5140

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -718,6 +718,10 @@ paths:
             - telephone-call
             - office-visit
             - video-call
+        - name: filter[overdue]
+          in: query
+          type: boolean
+          description: If not specified, return all calendar events. If set to `true` return only events that have started but not yet ended nor completed, if set to `false`, return only events that have either not started, or have ended, or completed.
         - name: filter[completed]
           in: query
           type: boolean
@@ -737,6 +741,16 @@ paths:
           type: string
           description: |
             The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events completed in November 2017 (America/New_York): `filter[completed_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
+        - name: filter[occurred_at]
+          in: query
+          type: string
+          description: |
+            Includes events with start_at, end_at, or completed_at occurred within the specified date range. The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events completed in November 2017 (America/New_York): `filter[occurred_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
+        - name: filter[active_at]
+          in: query
+          type: string
+          description: |
+            Includes events with end_at, or completed_at occurred within the specified date range. The start (inclusive) and end (exclusive) dates are ISO date and time strings separated by `..`. Example for events completed in November 2017 (America/New_York): `filter[active_at]=2017-11-01T00:00:00-04:00..2017-12-01T00:00:00-05:00`
         - name: filter[created_at]
           in: query
           type: string

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -828,7 +828,7 @@ paths:
       tags:
         - calendar event
       summary: Update a calendar event
-      description: Update a calendar event for a patient. Attribute `all_day` must be true and `end_at` cannot be specified for `plan-check-in` event type. To mark a calendar event as 'completed', set `completed_at` and `completed_by` to desired values.  To mark a completed calendar event as 'not completed', set `completed_at` and `completed_by` to `null`.
+      description: Update a calendar event for a patient. Attribute `all_day` must be true and `end_at` cannot be specified for `plan-check-in` event type. To mark a calendar event as 'completed', set `completed_at`, `completed_by` to desired values and set `incomplete_reason` to `null`.  To mark a completed calendar event as 'not completed', set `completed_at` and `completed_by` to `null`, include an optional values for `incomplete_reason`.
       operationId: updateCalendarEvent
       parameters:
         - name: id
@@ -3337,6 +3337,19 @@ definitions:
             format: ISODate
             example: '2017-11-03T06:17:34.652Z'
             description: 'The date and time when the calendar event is marked as completed. Only valid for `plan-check-in` event type.'
+          incomplete_reason:
+            type: string
+            description: 'A reason for the calendar event not being marked as completed.'
+            enum:
+              - voicemail
+              - no_show
+              - requested_reschedule
+              - canceled_by_participant
+              - canceled_by_coach
+              - technical_difficulties
+              - unable_to_connect
+              - incorrectly_scheduled
+              - double_booked
           type:
             type: string
             description: 'The type of calendar event. Immutable after event creation.'


### PR DESCRIPTION
Added `overdue`, 'occurred_at`, `active_at` and `incomplete_reason` attributes to calendar event apis.