### PR TITLE
Changed page[after] to page[cursor]

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1932,7 +1932,7 @@ paths:
           required: false
           default: 50
           minimum: 0
-        - name: page[after]
+        - name: page[cursor]
           in: query
           description: Page cursor
           type: string


### PR DESCRIPTION
Fixed `page[after]` as it should be `page[cursor]`.